### PR TITLE
Remove dup changelog items; Reassign icon families

### DIFF
--- a/design/META.json
+++ b/design/META.json
@@ -1274,7 +1274,7 @@
         {
             "name": "Silo",
             "filename": "silo.svg",
-            "family": ["Agriculture", "Building"],
+            "family": ["Agriculture", "Maps"],
             "style": "baseline",
             "tags": ["farm", "feed", "food", "grain", "structure"],
             "author": "Unknown",
@@ -1761,7 +1761,7 @@
         {
             "name": "Building",
             "filename": "building.svg",
-            "family": ["industrial"],
+            "family": ["Maps"],
             "style": "baseline",
             "tags": ["pins", "places", "locations", "office"],
             "author": "GreenTurtwig",
@@ -4300,7 +4300,7 @@
         {
             "name": "Garage Closed",
             "filename": "garage_closed.svg",
-            "family": ["System"],
+            "family": ["Maps"],
             "style": "baseline",
             "tags": ["car", "door", "shed", "storage", "tool", "house"],
             "author": "Michael Irigoyen",

--- a/packages/icon-font/CHANGELOG.md
+++ b/packages/icon-font/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed, Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
+-   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
 
 ## v2.1.0 (Feb 28, 2023)
 

--- a/packages/mui/CHANGELOG.md
+++ b/packages/mui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed, Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
+-   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
 
 ## v3.4.0 (Feb 28, 2023)
 

--- a/packages/mui/index.json
+++ b/packages/mui/index.json
@@ -1274,7 +1274,7 @@
         {
             "name": "Silo",
             "filename": "silo.svg",
-            "family": ["Agriculture", "Building"],
+            "family": ["Agriculture", "Maps"],
             "style": "baseline",
             "tags": ["farm", "feed", "food", "grain", "structure"],
             "author": "Unknown",
@@ -1761,7 +1761,7 @@
         {
             "name": "Building",
             "filename": "building.svg",
-            "family": ["industrial"],
+            "family": ["Maps"],
             "style": "baseline",
             "tags": ["pins", "places", "locations", "office"],
             "author": "GreenTurtwig",
@@ -4300,7 +4300,7 @@
         {
             "name": "Garage Closed",
             "filename": "garage_closed.svg",
-            "family": ["System"],
+            "family": ["Maps"],
             "style": "baseline",
             "tags": ["car", "door", "shed", "storage", "tool", "house"],
             "author": "Michael Irigoyen",

--- a/packages/rn-vector/CHANGELOG.md
+++ b/packages/rn-vector/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed, Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
+-   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
 
 ## v2.1.0 (Feb 28, 2023)
 

--- a/packages/svg/CHANGELOG.md
+++ b/packages/svg/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## v1.13.1 (July 3, 2023)
+
+### Changed
+
+-   Reassigned 3 icons (Silo, Building, Garage Closed) to the family "maps".
+
 ## v1.13.0 (June 30, 2023)
 
 ### Added
 
--   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed, Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
+-   New icons: Cloud Done, Cloud Off Filled, Utility Disabled, File CSV, Breaker Closed, Battery Disabled, EV Plug IEC 61851 GB/T, Notification Active Outline, Battery Disabled Alt, Sitemap Outline, Warehouse Alt, Floor Plan, Garage Closed.
 
 ## v1.12.0 (Feb 28, 2023)
 

--- a/packages/svg/index.json
+++ b/packages/svg/index.json
@@ -1274,7 +1274,7 @@
         {
             "name": "Silo",
             "filename": "silo.svg",
-            "family": ["Agriculture", "Building"],
+            "family": ["Agriculture", "Maps"],
             "style": "baseline",
             "tags": ["farm", "feed", "food", "grain", "structure"],
             "author": "Unknown",
@@ -1761,7 +1761,7 @@
         {
             "name": "Building",
             "filename": "building.svg",
-            "family": ["industrial"],
+            "family": ["Maps"],
             "style": "baseline",
             "tags": ["pins", "places", "locations", "office"],
             "author": "GreenTurtwig",
@@ -4300,7 +4300,7 @@
         {
             "name": "Garage Closed",
             "filename": "garage_closed.svg",
-            "family": ["System"],
+            "family": ["Maps"],
             "style": "baseline",
             "tags": ["car", "door", "shed", "storage", "tool", "house"],
             "author": "Michael Irigoyen",

--- a/packages/svg/package.json
+++ b/packages/svg/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/icons-svg",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "description": "SVG icons for Eaton applications",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Reassigned 3 icons (Silo, Building, Garage Closed) to the family "maps". 
- Removed dup changelog items;
- I will update the changelog date in `packages/svg/CHANGELOG.md` to whenever this is approved
